### PR TITLE
Fix race condition in RNG

### DIFF
--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -1,0 +1,21 @@
+package snapshot
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestRandomGeneratorImpl_Random_Race(t *testing.T) {
+	rgi := &randomGeneratorImpl{random: rand.New(rand.NewSource(time.Now().UnixNano()))}
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			rgi.Random()
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		rgi.Random()
+	}
+}


### PR DESCRIPTION
While the package-level methods in rand are concurrency safe (via a mutex), using a custom rand.Source is not. This in turn leads to panics when calling any generative methods on it (probably due to accessing /dev/urand or an equivalent source of entropy). This patch follows the behavior of the package-level methods and gates the calls behind a mutex.