### PR TITLE
Adding FeatureEnabledForID for 'sticky' features

### DIFF
--- a/snapshot/mock.go
+++ b/snapshot/mock.go
@@ -37,6 +37,13 @@ func (m *Mock) Set(key string, val string) *Mock {
 	return m
 }
 
+// SetUInt64 set the entry for `key` to `val` as a uint64
+func (m *Mock) SetUInt64(key string, val uint64) *Mock {
+	m.Snapshot.entries[key] = entry.New("", val, true)
+
+	return m
+}
+
 // FeatureEnabled overrides the internal `Snapshot`s `FeatureEnabled`
 func (m *Mock) FeatureEnabled(key string, defaultValue uint64) bool {
 	if e, ok := m.Snapshot.entries[key]; ok {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRandomGeneratorImpl_Random_Race(t *testing.T) {
@@ -18,4 +20,24 @@ func TestRandomGeneratorImpl_Random_Race(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		rgi.Random()
 	}
+}
+
+func TestSnapshot_FeatureEnabledForID(t *testing.T) {
+	key := "test"
+	ss := NewMock()
+	ss.SetUInt64(key, 100)
+	assert.True(t, ss.FeatureEnabledForID(key, 1))
+
+	ss.SetUInt64(key, 0)
+	assert.False(t, ss.FeatureEnabledForID(key, 1))
+
+	enabled := 0
+	for i := 1; i < 101; i++ {
+		ss.SetUInt64(key, uint64(i))
+		if ss.FeatureEnabledForID(key, uint64(i)) {
+			enabled++
+		}
+	}
+
+	assert.Equal(t, 47, enabled)
 }


### PR DESCRIPTION
This branch adds `FeatureEnabledForID` that allows features to be sticky for a given `uint64` ID. The ID and feature key are concatenated and are then converted to a `CRC32` hash. The result is then checked to if it falls within the features value of 0-100. If this condition is true the feature is considered `enabled`. If a features value is not of a `uint64` type the feature will return disabled.
