### PR TITLE
Entry: expose modified timestamp of the runtime entry

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -111,17 +111,22 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 
 		key = strings.Replace(key, "/", ".", -1)
 		stringValue := string(contents)
-		entry := entry.New(stringValue, 0, false)
+		e := &entry.Entry{
+			StringValue: stringValue,
+			Uint64Value: 0,
+			Uint64Valid: false,
+			Modified:    info.ModTime(),
+		}
 
 		uint64Value, err := strconv.ParseUint(strings.TrimSpace(stringValue), 10, 64)
 		if err == nil {
-			entry.Uint64Value = uint64Value
-			entry.Uint64Valid = true
+			e.Uint64Value = uint64Value
+			e.Uint64Valid = true
 		}
 
 		logger.Debugf("runtime: adding key=%s value=%s uint=%t", key,
-			stringValue, entry.Uint64Valid)
-		l.nextSnapshot.SetEntry(key, entry)
+			stringValue, e.Uint64Valid)
+		l.nextSnapshot.SetEntry(key, e)
 	}
 
 	return nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -69,6 +69,9 @@ func TestSymlinkRefresher(t *testing.T) {
 	assert.Equal(uint64(7), snapshot.GetInteger("dir.file2", 7))
 	assert.Equal(uint64(34), snapshot.GetInteger("dir2.file3", 100))
 
+	info, _ := os.Stat(tempDir + "/testdir1/app/file1")
+	assert.Equal(info.ModTime(), snapshot.GetModified("file1"))
+
 	keys := snapshot.Keys()
 	sort.Strings(keys)
 	assert.EqualValues([]string{"dir.file2", "dir2.file3", "file1"}, keys)

--- a/snapshot/entry/entry.go
+++ b/snapshot/entry/entry.go
@@ -1,14 +1,11 @@
 package entry
 
+import "time"
+
 // An individual snapshot entry. Optimized for integers by pre-converting them if possible.
 type Entry struct {
 	StringValue string
 	Uint64Value uint64
 	Uint64Valid bool
-}
-
-func New(s string, ui uint64, v bool) (e *Entry) {
-	e = &Entry{s, ui, v}
-
-	return
+	Modified    time.Time
 }

--- a/snapshot/iface.go
+++ b/snapshot/iface.go
@@ -1,6 +1,10 @@
 package snapshot
 
-import "github.com/lyft/goruntime/snapshot/entry"
+import (
+	"time"
+
+	"github.com/lyft/goruntime/snapshot/entry"
+)
 
 // Snapshot provides the currently loaded set of runtime values.
 type IFace interface {
@@ -36,6 +40,10 @@ type IFace interface {
 	//        contain an integer.
 	// @return uint64 the runtime value or the default value.
 	GetInteger(key string, defaultValue uint64) uint64
+
+	// GetModified returns the last modified timestamp for key. If key does not
+	// exist, the zero value for time.Time is returned.
+	GetModified(key string) time.Time
 
 	// Fetch all keys inside the snapshot.
 	// @return []string all of the keys.

--- a/snapshot/mock.go
+++ b/snapshot/mock.go
@@ -1,6 +1,10 @@
 package snapshot
 
-import "github.com/lyft/goruntime/snapshot/entry"
+import (
+	"time"
+
+	"github.com/lyft/goruntime/snapshot/entry"
+)
 
 // Mock provides a Snapshot implementation for testing
 type Mock struct {
@@ -18,28 +22,48 @@ func NewMock() (s *Mock) {
 
 // SetEnabled overrides the entry for `key` to be enabled
 func (m *Mock) SetEnabled(key string) *Mock {
-	m.Snapshot.entries[key] = entry.New(key, 0, true)
+	m.Snapshot.entries[key] = &entry.Entry{
+		StringValue: key,
+		Uint64Value: 0,
+		Uint64Valid: true,
+		Modified:    time.Now(),
+	}
 
 	return m
 }
 
 // SetDisabled overrides the entry for `key` to be disabled
 func (m *Mock) SetDisabled(key string) *Mock {
-	m.Snapshot.entries[key] = entry.New(key, 0, false)
+	m.Snapshot.entries[key] = &entry.Entry{
+		StringValue: key,
+		Uint64Value: 0,
+		Uint64Valid: false,
+		Modified:    time.Now(),
+	}
 
 	return m
 }
 
 // Set set the entry for `key` to `val`
 func (m *Mock) Set(key string, val string) *Mock {
-	m.Snapshot.entries[key] = entry.New(val, 0, false)
+	m.Snapshot.entries[key] = &entry.Entry{
+		StringValue: val,
+		Uint64Value: 0,
+		Uint64Valid: false,
+		Modified:    time.Now(),
+	}
 
 	return m
 }
 
 // SetUInt64 set the entry for `key` to `val` as a uint64
 func (m *Mock) SetUInt64(key string, val uint64) *Mock {
-	m.Snapshot.entries[key] = entry.New("", val, true)
+	m.Snapshot.entries[key] = &entry.Entry{
+		StringValue: "",
+		Uint64Value: val,
+		Uint64Valid: true,
+		Modified:    time.Now(),
+	}
 
 	return m
 }

--- a/snapshot/nil.go
+++ b/snapshot/nil.go
@@ -1,6 +1,10 @@
 package snapshot
 
-import "github.com/lyft/goruntime/snapshot/entry"
+import (
+	"time"
+
+	"github.com/lyft/goruntime/snapshot/entry"
+)
 
 // Implementation of Snapshot for the nilLoaderImpl.
 type Nil struct{}
@@ -21,9 +25,9 @@ func (n *Nil) FeatureEnabledForID(key string, id uint64, defaultPercentage uint3
 
 func (n *Nil) Get(key string) string { return "" }
 
-func (n *Nil) GetInteger(key string, defaultValue uint64) uint64 {
-	return defaultValue
-}
+func (n *Nil) GetInteger(key string, defaultValue uint64) uint64 { return defaultValue }
+
+func (n *Nil) GetModified(key string) time.Time { return time.Time{} }
 
 func (n *Nil) Keys() []string {
 	return []string{}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -88,6 +88,16 @@ func (s *Snapshot) GetInteger(key string, defaultValue uint64) uint64 {
 	}
 }
 
+// GetModified returns the last modified timestamp for key. If key does not
+// exist, the zero value for time.Time is returned.
+func (s *Snapshot) GetModified(key string) time.Time {
+	if e, ok := s.entries[key]; ok {
+		return e.Modified
+	}
+
+	return time.Time{}
+}
+
 func (s *Snapshot) Keys() []string {
 	ret := []string{}
 	for key, _ := range s.entries {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lyft/goruntime/snapshot/entry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,4 +48,14 @@ func TestSnapshot_FeatureEnabledForIDDisabled(t *testing.T) {
 	ss := NewMock()
 	assert.True(t, ss.FeatureEnabledForID(key, 1, 100))
 	assert.False(t, ss.FeatureEnabledForID(key, 1, 0))
+}
+
+func TestSnapshot_GetModified(t *testing.T) {
+	ss := NewMock()
+
+	assert.True(t, ss.GetModified("foo").IsZero())
+
+	now := time.Now()
+	ss.entries["foo"] = &entry.Entry{Modified: now}
+	assert.Equal(t, now, ss.GetModified("foo"))
 }


### PR DESCRIPTION
This patch exposes the last modified timestamp for a Runtime entry, accessible via the snapshot or from the `Entry` directly. For the default loader, this value is derived from the `os.Stat` for the entry file. Unknown keys return the zero `time.Time`.