### PR TITLE
Use Dir instead of Base in DirectoryRefresher

### DIFF
--- a/loader/directory_refresher.go
+++ b/loader/directory_refresher.go
@@ -12,8 +12,8 @@ func (d *DirectoryRefresher) WatchDirectory(runtimePath string, appDirPath strin
 }
 
 func (d *DirectoryRefresher) ShouldRefresh(path string, op FileSystemOp) bool {
-	if filepath.Base(path) == d.currDir &&
-		op == Write || op == Create || op == Chmod {
+	if filepath.Dir(path) == d.currDir &&
+		(op == Write || op == Create || op == Chmod) {
 		return true
 	}
 	return false

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -10,10 +10,10 @@ import (
 
 	"time"
 
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	)
+)
 
 var nullScope = stats.NewStore(stats.NewNullSink(), false)
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -10,10 +10,10 @@ import (
 
 	"time"
 
-	stats "github.com/lyft/gostats"
+	"github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-)
+	)
 
 var nullScope = stats.NewStore(stats.NewNullSink(), false)
 
@@ -158,4 +158,17 @@ func TestDirectoryRefresher(t *testing.T) {
 
 	snapshot = loader.Snapshot()
 	assert.Equal("hello2", snapshot.Get("file2"))
+
+	// Write to the file
+	f, err := os.OpenFile(appDir+"/file2", os.O_RDWR, os.ModeAppend)
+	assert.NoError(err)
+	_, err = f.WriteString("hello3")
+	assert.NoError(err)
+	f.Sync()
+
+	// Wait for the update
+	<-runtime_update
+
+	snapshot = loader.Snapshot()
+	assert.Equal("hello3", snapshot.Get("file2"))
 }


### PR DESCRIPTION
DirectoryRefresher is unable to pick up updates because the condition `filepath.Base(path) == d.currDir` effectively is never true. I think the intention was to use `filepath.Dir` here instead of `filepath.Base` (which fetches only the last part of the path)

Tests didn't catch this issue because of the malformed conditional. The tests only used file creates, which pass because of `|| op == Create`