### PR TITLE
add support for float sample rates

### DIFF
--- a/snapshot/feature_enabled.go
+++ b/snapshot/feature_enabled.go
@@ -1,0 +1,77 @@
+package snapshot
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"errors"
+)
+
+type SampleRate float64
+
+const (
+	Off SampleRate = 0
+	Max SampleRate = 100
+)
+
+type Rand interface {
+	// Float64 has the same contract as rand.Rand.Float64 in the standard
+	// library
+	Float64() float64
+}
+
+func (s SampleRate) MultipliedBy(r SampleRate) SampleRate {
+	p := float64(s) * float64(r) / 100
+	return SampleRate(p)
+}
+
+func (s SampleRate) String() string {
+	return strconv.FormatFloat(float64(s), 'f', 6, 64)
+}
+
+func GetSampleRateOrDefault(runtime IFace, key string, defaultValue SampleRate) SampleRate {
+	s, err := GetSampleRate(runtime, key)
+	if err != nil {
+		return defaultValue
+	}
+
+	return s
+}
+
+func IsSampleRateDefined(runtime IFace, key string) bool {
+	_, err := GetSampleRate(runtime, key)
+	return err == nil
+}
+
+func GetSampleRate(runtime IFace, key string) (SampleRate, error) {
+	if runtime.Get(key) == "" {
+		return Off, errors.New("Key does not exist")
+	}
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(runtime.Get(key)), 64)
+	if err != nil {
+		return Off, err
+	}
+
+	if parsed < 0 || parsed > 100 {
+		return Off, errors.New("Invalid sample rate")
+	}
+
+	return SampleRate(parsed), nil
+}
+
+// FeatureEnabledF extracts a float |value| from a runtime snapshot given a
+// string key and returns true |value| percent of the time.
+//
+// NB: supports floating point granularity.
+//
+// NB: if a value cannot be found for the given runtime |key|, this function
+// returns true |defaultValue| percent of the time
+func FeatureEnabledF(runtime IFace, r Rand, key string, defaultValue SampleRate) bool {
+	parsed := GetSampleRateOrDefault(runtime, key, defaultValue)
+	return FeatureEnabled(r, parsed)
+}
+
+func FeatureEnabled(r Rand, s SampleRate) bool {
+	return r.Float64()*100 < math.Min(float64(s), 100)
+}

--- a/snapshot/feature_enabled_test.go
+++ b/snapshot/feature_enabled_test.go
@@ -1,0 +1,121 @@
+package snapshot
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureEnabledF(t *testing.T) {
+
+	// defaultValue is the percentage used when the key is missing from the
+	// snapshot or the value is invalid.
+	//
+	// an arbitrary value within the range is used to ensure that the function
+	// does not fall back to 0 or 100.
+	const defaultValue SampleRate = 69
+
+	type TestCase struct {
+		RuntimeConfigPercentage string
+		Delta                   float64
+		ExpectedPercentage      SampleRate
+	}
+
+	var cases []TestCase
+
+	{
+		boundaryCases := []string{
+			"0",
+			"100",
+		}
+		for _, c := range boundaryCases {
+			f, err := strconv.ParseFloat(c, 64)
+			if err != nil {
+				t.Fatal("malformed test case")
+			}
+			cases = append(cases, TestCase{
+				RuntimeConfigPercentage: c,
+				ExpectedPercentage:      SampleRate(f), // should be parsed value
+				Delta:                   0,             // percentage should match the expected exactly
+			})
+		}
+
+		validVals := []string{ // in (0, 100)
+			"1",
+			"2.5",
+			"5",
+			"10",
+			"20.1",
+			"40",
+			"80",
+			"99",
+		}
+		for _, c := range validVals {
+			f, err := strconv.ParseFloat(c, 64)
+			if err != nil {
+				t.Fatal("malformed test case")
+			}
+			cases = append(cases, TestCase{
+				RuntimeConfigPercentage: c,
+				ExpectedPercentage:      SampleRate(f),
+				Delta:                   1, // some deviation is expected
+			})
+		}
+
+		invalid := []string{
+			"-1",
+			"101",
+			"foo",
+		}
+		for _, c := range invalid {
+			cases = append(cases, TestCase{
+				RuntimeConfigPercentage: c,
+				ExpectedPercentage:      defaultValue, // should fall back to default
+				Delta:                   1,            // some deviation is expected
+			})
+		}
+
+		misc := []TestCase{
+			{
+				RuntimeConfigPercentage: "\t50.5    \n", // a valid value with white space
+				ExpectedPercentage:      50.5,
+				Delta:                   1, // some deviation is expected
+			},
+		}
+		for _, tc := range misc {
+			cases = append(cases, tc)
+		}
+	}
+
+	for _, c := range cases {
+
+		const (
+			seed = 1 // for determinism
+			key  = "doesntmatter"
+		)
+
+		s := NewMock()
+		s.Set(key, c.RuntimeConfigPercentage)
+		r := rand.New(rand.NewSource(seed))
+		percentActual := percentTrue(10000, func() bool {
+			return FeatureEnabledF(s, r, key, defaultValue)
+		})
+
+		assert.InDelta(t, float64(c.ExpectedPercentage), percentActual, c.Delta, fmt.Sprintln(c))
+	}
+}
+
+// percentTrue runs |f| n times, returning the [0, 100] rate at which f returns
+// true
+func percentTrue(n int, f func() bool) float64 {
+	var numTrue float64 = 0
+	for i := 0; i < n; i++ {
+		if f() {
+			numTrue += 1
+		}
+	}
+	return numTrue / float64(n) * 100
+}


### PR DESCRIPTION
this PR adds helpers to work with floating point sample rates.

I hope to spark a discussion about the best way to actually add this functionality. 

this is being upstreamed from: https://github.com/lyft/eventingest/tree/master/thirdparty/runtime

1. Do we have appetite to break call-sites that are depending on the IFace's exact method listing? right now, it is impl'd as a free function, but that's not ideal.
1. do we care for a sample rate microtype? in practice, i have appreciated the clarity at call-sites.