### PR TITLE
loader: improve fsnotify error message

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -164,7 +164,7 @@ func IgnoreDotFiles(l *Loader) { l.ignoreDotfiles = true }
 
 func New(runtimePath string, runtimeSubdirectory string, scope stats.Scope, refresher Refresher, opts ...Option) IFace {
 	if runtimePath == "" || runtimeSubdirectory == "" {
-		logger.Warnf("no runtime configuration. using nil loader.")
+		logger.Warn("no runtime configuration. using nil loader.")
 		return NewNil()
 	}
 	watchedPath := refresher.WatchDirectory(runtimePath, runtimeSubdirectory)
@@ -206,7 +206,7 @@ func New(runtimePath string, runtimeSubdirectory string, scope stats.Scope, refr
 					newLoader.onRuntimeChanged()
 				}
 			case err := <-watcher.Errors:
-				logger.Warnf("runtime watch error:", err)
+				logger.Warnf("runtime watch error: %s", err)
 			}
 		}
 	}()

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -171,13 +171,17 @@ func New(runtimePath string, runtimeSubdirectory string, scope stats.Scope, refr
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		logger.Fatalf("unable to create runtime watcher %+v", err)
+		// If this fails with EMFILE (0x18) it is likely due to
+		// inotify_init1() and fs.inotify.max_user_instances.
+		//
+		// Include the error message, type and value - this is
+		// particularly useful if the error is a syscall.Errno.
+		logger.Panicf("unable to create runtime watcher: %[1]s (%[1]T %#[1]v)\n", err)
 	}
 
 	err = watcher.Add(watchedPath)
-
 	if err != nil {
-		logger.Fatalf("unable to create runtime watcher %+v", err)
+		logger.Panicf("unable to watch file (%[1]s): %[2]s (%[2]T %#[2]v)", watchedPath, err)
 	}
 
 	newLoader := Loader{


### PR DESCRIPTION
Use different error messages for failing to create a watcher and watching a file.  Additionally, use Panicf() instead of Fatalf() otherwise it is impossible to identify the calling function.

Note: this library *really* should not be be calling Fatal or Panic, but should instead be returning an error.