### PR TITLE
loader: use atomic.Value to store snapshot

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -190,3 +190,19 @@ func TestDirectoryRefresher(t *testing.T) {
 	snapshot = loader.Snapshot()
 	assert.Equal("hello3", snapshot.Get("file2"))
 }
+
+func BenchmarkSnapsot(b *testing.B) {
+	var ll Loader
+	for i := 0; i < b.N; i++ {
+		ll.Snapshot()
+	}
+}
+
+func BenchmarkSnapsot_Parallel(b *testing.B) {
+	ll := new(Loader)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ll.Snapshot()
+		}
+	})
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -191,14 +191,14 @@ func TestDirectoryRefresher(t *testing.T) {
 	assert.Equal("hello3", snapshot.Get("file2"))
 }
 
-func BenchmarkSnapsot(b *testing.B) {
+func BenchmarkSnapshot(b *testing.B) {
 	var ll Loader
 	for i := 0; i < b.N; i++ {
 		ll.Snapshot()
 	}
 }
 
-func BenchmarkSnapsot_Parallel(b *testing.B) {
+func BenchmarkSnapshot_Parallel(b *testing.B) {
 	ll := new(Loader)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {


### PR DESCRIPTION
This eliminates the need to use a mutex.

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkSnapsot-12              15.1          2.46          -83.71%
BenchmarkSnapsot_Parallel-12     36.6          0.51          -98.60%
```