### PR TITLE
loader: remove debug logging for 4x speedup

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -54,8 +54,6 @@ func (l *Loader) AddUpdateCallback(callback chan<- int) {
 
 func (l *Loader) onRuntimeChanged() {
 	targetDir := filepath.Join(l.watchPath, l.subdirectory)
-	logger.Debugf("runtime changed. loading new snapshot at %s",
-		targetDir)
 
 	l.nextSnapshot = snapshot.New()
 	filepath.Walk(targetDir, l.walkDirectoryCallback)
@@ -83,7 +81,6 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 		return nil
 	}
 
-	logger.Debugf("runtime: processing %s", path)
 	if l.ignoreDotfiles && info.IsDir() && strings.HasPrefix(info.Name(), ".") {
 		return filepath.SkipDir
 	}
@@ -126,8 +123,6 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 			e.Uint64Valid = true
 		}
 
-		logger.Debugf("runtime: adding key=%s value=%s uint=%t", key,
-			stringValue, e.Uint64Valid)
 		l.nextSnapshot.SetEntry(key, e)
 	}
 
@@ -194,7 +189,6 @@ func New2(runtimePath, runtimeSubdirectory string, scope stats.Scope, refresher 
 		for {
 			select {
 			case ev := <-watcher.Events:
-				logger.Debugf("Got event %s", ev)
 				if refresher.ShouldRefresh(ev.Name, getFileSystemOp(ev)) {
 					newLoader.onRuntimeChanged()
 				}


### PR DESCRIPTION
This commit removes Debugf() logging, which when benchmarked with
internal runtime repos shows a 4x speedup.

TODO: replace logrus with zap.