### PR TITLE
loader/snapshot: don't alloc for Nil loader/snapshot

### DIFF
--- a/loader/nil.go
+++ b/loader/nil.go
@@ -4,17 +4,13 @@ import "github.com/lyft/goruntime/snapshot"
 
 // Implementation of Loader with no backing store.
 type Nil struct {
-	snapshot *snapshot.Nil
+	snapshot snapshot.Nil
 }
 
-func NewNil() (n *Nil) {
-	n = &Nil{
-		snapshot: snapshot.NewNil(),
-	}
-
-	return
+func NewNil() Nil {
+	return Nil{}
 }
 
-func (n *Nil) Snapshot() snapshot.IFace { return n.snapshot }
+func (n Nil) Snapshot() snapshot.IFace { return n.snapshot }
 
-func (n *Nil) AddUpdateCallback(callback chan<- int) {}
+func (Nil) AddUpdateCallback(callback chan<- int) {}

--- a/loader/nil_test.go
+++ b/loader/nil_test.go
@@ -1,0 +1,18 @@
+package loader
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestNil(t *testing.T) {
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = NewNil()
+	})
+	if allocs != 0 {
+		t.Errorf("NewNil should not alloc got: %f", allocs)
+	}
+	if unsafe.Sizeof(Nil{}) != 0 {
+		t.Errorf("Nil should have size 0 got: %d", unsafe.Sizeof(Nil{}))
+	}
+}

--- a/snapshot/nil.go
+++ b/snapshot/nil.go
@@ -9,32 +9,34 @@ import (
 // Implementation of Snapshot for the nilLoaderImpl.
 type Nil struct{}
 
-func NewNil() (s *Nil) {
-	s = &Nil{}
+func NewNil() Nil { return Nil{} }
 
-	return
-}
-
-func (n *Nil) FeatureEnabled(key string, defaultValue uint64) bool {
+func (Nil) FeatureEnabled(_ string, defaultValue uint64) bool {
 	return defaultRandomGenerator.Random()%100 < min(defaultValue, 100)
 }
 
-func (n *Nil) FeatureEnabledForID(key string, id uint64, defaultPercentage uint32) bool {
+func (Nil) FeatureEnabledForID(string, uint64, uint32) bool {
 	return true
 }
 
-func (n *Nil) Get(key string) string { return "" }
+func (Nil) Get(string) string {
+	return ""
+}
 
-func (n *Nil) GetInteger(key string, defaultValue uint64) uint64 { return defaultValue }
+func (Nil) GetInteger(_ string, defaultValue uint64) uint64 {
+	return defaultValue
+}
 
-func (n *Nil) GetModified(key string) time.Time { return time.Time{} }
+func (Nil) GetModified(string) time.Time {
+	return time.Time{}
+}
 
-func (n *Nil) Keys() []string {
+func (Nil) Keys() []string {
 	return []string{}
 }
 
-func (n *Nil) Entries() map[string]*entry.Entry {
-	return make(map[string]*entry.Entry)
+func (Nil) Entries() map[string]*entry.Entry {
+	return map[string]*entry.Entry{}
 }
 
-func (n *Nil) SetEntry(string, *entry.Entry) {}
+func (Nil) SetEntry(string, *entry.Entry) {}

--- a/snapshot/nil_test.go
+++ b/snapshot/nil_test.go
@@ -1,0 +1,18 @@
+package snapshot
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestNil(t *testing.T) {
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = NewNil()
+	})
+	if allocs != 0 {
+		t.Errorf("NewNil should not alloc got: %f", allocs)
+	}
+	if unsafe.Sizeof(Nil{}) != 0 {
+		t.Errorf("Nil should have size 0 got: %d", unsafe.Sizeof(Nil{}))
+	}
+}


### PR DESCRIPTION
A zero sized struct can be used for the Nil snapshot and thus loader.
This commit changes both to use zero sized structs. This is mostly for
correctness and does not change the implementation.