### PR TITLE
Make high cardinality logs trace

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -83,7 +83,6 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 		return nil
 	}
 
-	logger.Tracef("runtime: processing %s", path)
 	if l.ignoreDotfiles && info.IsDir() && strings.HasPrefix(info.Name(), ".") {
 		return filepath.SkipDir
 	}
@@ -126,7 +125,6 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 			e.Uint64Valid = true
 		}
 
-		logger.Tracef("runtime: adding key=%s value=%s uint=%t", key,
 			stringValue, e.Uint64Valid)
 		l.nextSnapshot.SetEntry(key, e)
 	}
@@ -194,7 +192,6 @@ func New2(runtimePath, runtimeSubdirectory string, scope stats.Scope, refresher 
 		for {
 			select {
 			case ev := <-watcher.Events:
-				logger.Debugf("Got event %s", ev)
 				if refresher.ShouldRefresh(ev.Name, getFileSystemOp(ev)) {
 					newLoader.onRuntimeChanged()
 				}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -54,7 +54,7 @@ func (l *Loader) AddUpdateCallback(callback chan<- int) {
 
 func (l *Loader) onRuntimeChanged() {
 	targetDir := filepath.Join(l.watchPath, l.subdirectory)
-	logger.Debugf("runtime changed. loading new snapshot at %s",
+	logger.Tracef("runtime changed. loading new snapshot at %s",
 		targetDir)
 
 	l.nextSnapshot = snapshot.New()
@@ -83,7 +83,7 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 		return nil
 	}
 
-	logger.Debugf("runtime: processing %s", path)
+	logger.Tracef("runtime: processing %s", path)
 	if l.ignoreDotfiles && info.IsDir() && strings.HasPrefix(info.Name(), ".") {
 		return filepath.SkipDir
 	}
@@ -126,7 +126,7 @@ func (l *Loader) walkDirectoryCallback(path string, info os.FileInfo, err error)
 			e.Uint64Valid = true
 		}
 
-		logger.Debugf("runtime: adding key=%s value=%s uint=%t", key,
+		logger.Tracef("runtime: adding key=%s value=%s uint=%t", key,
 			stringValue, e.Uint64Valid)
 		l.nextSnapshot.SetEntry(key, e)
 	}


### PR DESCRIPTION
The sheer amount of log volume generated by this makes it impossible for me to see anything else that's relevant in an integration test when it fails. Can we downlevel this to trace? 

https://ciartifactproxy.lyft.net/artifact/task:jim3:jimM:1I8vat4XNIg:0/s3/jenkins-console-output.html

I'd be super stoked to hear about any other way to suppress these logs without having to do this.