### PR TITLE
loader: make AddUpdateCallback thread-safe and don't block signaling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo:     required
 language: go
 go:
-  - "1.12"
   - "1.13"
+  - "1.14"
+  - "1.15"
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
This commit makes the Loader.AddUpdateCallback() method thread-safe and
ensures that signaling callbacks never blocks. Previously, if signaling
a callback blocked it would deadlock the Loader.